### PR TITLE
Adding AMD support per #7

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,5 +23,8 @@
   "sub"       : true,
   "strict"    : true,
   "white"     : false,
-  "indent"    : 2
+  "indent"    : 2,
+  "globals"   : {
+    "define" : false
+  }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,7 @@ module.exports = function(grunt) {
           }
         }
       }
+    }
   });
 
   // Load NPM Tasks

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,20 @@ module.exports = function(grunt) {
           }
         }
       }
-    }
+    },
+    browserAMD: {
+      src: ['src/corti.js'],
+      options: {
+        specs: 'test/spec/*Spec.js',
+        outfile: 'test/SpecRunner.html',
+        //vendor: ['test/vendor/corti.js', 'test/init_corti.js'], // https://github.com/cloudchen/grunt-template-jasmine-requirejs/issues/72
+        template: require('grunt-template-jasmine-requirejs'),
+        templateOptions: {
+          requireConfig: {
+            baseUrl: '../'
+          }
+        }
+      }
   });
 
   // Load NPM Tasks

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-jasmine": "^1.0.3",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-template-jasmine-istanbul": "^0.5.0"
+    "grunt-template-jasmine-istanbul": "^0.5.0",
+    "grunt-template-jasmine-requirejs": "^0.2.3"
   }
 }

--- a/src/corti.js
+++ b/src/corti.js
@@ -9,12 +9,12 @@
   // jshint strict: false
   if (typeof define === 'function' && define.amd) { // AMD
     define([], function () {
-      return (root.corti = factory());
+      return (root.Corti = factory());
     });
   } else if (typeof module === 'object' && module.exports) { // CommonJS
     module.exports = factory();
   } else { // Browser globals
-    root.corti = factory();
+    root.Corti = factory();
   }
 }(typeof window !== 'undefined' ? window : this, function () {
   "use strict";
@@ -176,7 +176,7 @@
 
   // Expose functionality
   corti = {
-    patch: function(root) {
+    patch: function() {
       if (_productionVersion === false) {
         _productionVersion = root.SpeechRecognition ||
           root.webkitSpeechRecognition ||
@@ -187,7 +187,7 @@
       root.SpeechRecognition = newSpeechRecognition;
     },
 
-    unpatch: function(root) {
+    unpatch: function() {
       root.SpeechRecognition = _productionVersion;
     }
   };

--- a/src/corti.js
+++ b/src/corti.js
@@ -9,14 +9,14 @@
   // jshint strict: false
   if (typeof define === 'function' && define.amd) { // AMD
     define([], function () {
-      return (root.Corti = factory());
+      return (root.Corti = factory(root));
     });
   } else if (typeof module === 'object' && module.exports) { // CommonJS
-    module.exports = factory();
+    module.exports = factory(root);
   } else { // Browser globals
-    root.Corti = factory();
+    root.Corti = factory(root);
   }
-}(typeof window !== 'undefined' ? window : this, function () {
+}(typeof window !== 'undefined' ? window : this, function (_root) {
   "use strict";
 
   var corti = {};
@@ -178,17 +178,18 @@
   corti = {
     patch: function() {
       if (_productionVersion === false) {
-        _productionVersion = root.SpeechRecognition ||
-          root.webkitSpeechRecognition ||
-          root.mozSpeechRecognition ||
-          root.msSpeechRecognition ||
-          root.oSpeechRecognition;
+        _productionVersion = 
+          _root.SpeechRecognition ||
+          _root.webkitSpeechRecognition ||
+          _root.mozSpeechRecognition ||
+          _root.msSpeechRecognition ||
+          _root.oSpeechRecognition;
       }
-      root.SpeechRecognition = newSpeechRecognition;
+      _root.SpeechRecognition = newSpeechRecognition;
     },
 
     unpatch: function() {
-      root.SpeechRecognition = _productionVersion;
+      _root.SpeechRecognition = _productionVersion;
     }
   };
   return corti;

--- a/src/corti.js
+++ b/src/corti.js
@@ -5,8 +5,8 @@
 //! https://github.com/TalAter/Corti
 
 (function (root, factory) {
-  // istanbul ignore next
   // jshint strict: false
+  // istanbul ignore next
   if (typeof define === 'function' && define.amd) { // AMD
     define([], function () {
       return (root.Corti = factory(root));
@@ -18,8 +18,6 @@
   }
 }(typeof window !== 'undefined' ? window : this, function (_root) {
   "use strict";
-
-  var corti = {};
 
   // Holds the browser's implementation
   var _productionVersion = false;
@@ -175,7 +173,7 @@
   };
 
   // Expose functionality
-  corti = {
+  return {
     patch: function() {
       if (_productionVersion === false) {
         _productionVersion = 
@@ -192,5 +190,4 @@
       _root.SpeechRecognition = _productionVersion;
     }
   };
-  return corti;
 }));

--- a/src/corti.js
+++ b/src/corti.js
@@ -4,11 +4,22 @@
 //! license : MIT
 //! https://github.com/TalAter/Corti
 
-(function (undefined) {
+(function (root, factory) {
+  // istanbul ignore next
+  // jshint strict: false
+  if (typeof define === 'function' && define.amd) { // AMD
+    define([], function () {
+      return (root.corti = factory());
+    });
+  } else if (typeof module === 'object' && module.exports) { // CommonJS
+    module.exports = factory();
+  } else { // Browser globals
+    root.corti = factory();
+  }
+}(typeof window !== 'undefined' ? window : this, function () {
   "use strict";
 
-  // Save a reference to the global object (window in the browser)
-  var _root = this;
+  var corti = {};
 
   // Holds the browser's implementation
   var _productionVersion = false;
@@ -164,21 +175,21 @@
   };
 
   // Expose functionality
-  _root.Corti = {
-    patch: function() {
+  corti = {
+    patch: function(root) {
       if (_productionVersion === false) {
-        _productionVersion = _root.SpeechRecognition ||
-          _root.webkitSpeechRecognition ||
-          _root.mozSpeechRecognition ||
-          _root.msSpeechRecognition ||
-          _root.oSpeechRecognition;
+        _productionVersion = root.SpeechRecognition ||
+          root.webkitSpeechRecognition ||
+          root.mozSpeechRecognition ||
+          root.msSpeechRecognition ||
+          root.oSpeechRecognition;
       }
-      _root.SpeechRecognition = newSpeechRecognition;
+      root.SpeechRecognition = newSpeechRecognition;
     },
 
-    unpatch: function() {
-      _root.SpeechRecognition = _productionVersion;
+    unpatch: function(root) {
+      root.SpeechRecognition = _productionVersion;
     }
   };
-
-}).call(this);
+  return corti;
+}));


### PR DESCRIPTION
I followed the example pattern presented in the annyang repo. The module now works via import and require syntax in node if window is defined. Might be nice to consider allowing access to the recognizer mock so it can be injected or attached. I've got a virtual window object for my use case (testing in Jest) but YMMV.
## Motivation and Context
#7
## How Has This Been Tested?

Ran all existing tests. Getting less than 99% code coverage even though ignoring the UMD as recommended by https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md means there should have been no coverage changes.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
